### PR TITLE
Fix link and fix to copy paste example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Building microservices is hard enough, but on top of that you have to choose a n
 
   * write a microservice (language of choice?) 
 
-## [Intro to Orchestrators (Kubernetes)](orhcestrators/runsheet.md)
+## [Intro to Orchestrators (Kubernetes)](orchestrators/runsheet.md)
 
   * Deploy on orchestrator (k8s or minikube)
 

--- a/orchestrators/runsheet.md
+++ b/orchestrators/runsheet.md
@@ -41,7 +41,7 @@ This will download and start weave scope
 
 Or simply 🤓
 ```bash
-$open http://$(minikube ip):$(kubectl describe service front-end \ 
+$open http://`(minikube ip):$(kubectl describe service front-end \ 
 | awk '$1 == "NodePort:" {print $3}' | cut -d/ -f1)
 ```
 This will open the front-end with the default browser


### PR DESCRIPTION
The link was not working because of a spelling error in orchestrators.
The code was not copy-pastable.